### PR TITLE
Fix error message check while stopping php-fpm

### DIFF
--- a/build-packages/magento-scripts/lib/tasks/php-fpm/stop-php-fpm.js
+++ b/build-packages/magento-scripts/lib/tasks/php-fpm/stop-php-fpm.js
@@ -23,7 +23,7 @@ const stopPhpFpmTask = {
             }
             await execAsyncSpawn(`kill ${processId} && rm -f ${php.fpmPidFilePath}`);
         } catch (e) {
-            if (e.message.includes('No such process')) {
+            if ((e.message && e.message.includes('No such process')) || e.includes('No such process')) {
                 await execAsyncSpawn(`rm -f ${php.fpmPidFilePath}`);
                 return;
             }


### PR DESCRIPTION
The error from trying to stop PHP fpm did not have a message attribute, but the message was located in the error variable. 
In this change I changed the message check so it first check if the message attribute exists and otherwise check the error itself for the message.

Fixes issue #16 