### PR TITLE
Better organisation of dev utils

### DIFF
--- a/build-packages/create-magento-app/index.js
+++ b/build-packages/create-magento-app/index.js
@@ -4,9 +4,9 @@ const path = require('path');
 const yargs = require('yargs');
 const semver = require('semver');
 const getLatestVersion = require('@scandipwa/scandipwa-dev-utils/latest-version');
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
-const createFilesystem = require('@scandipwa/scandipwa-dev-utils/create-filesystem');
-const shouldUseYarn = require('@scandipwa/scandipwa-dev-utils/should-use-yarn');
+const logger = require('@scandipwa/common-dev-utils/logger');
+const createFilesystem = require('@scandipwa/common-dev-utils/create-filesystem');
+const shouldUseYarn = require('@scandipwa/common-dev-utils/should-use-yarn');
 const installDeps = require('@scandipwa/scandipwa-dev-utils/install-deps');
 
 const greet = (name, pathname) => {

--- a/build-packages/create-magento-app/package.json
+++ b/build-packages/create-magento-app/package.json
@@ -8,6 +8,7 @@
     "bin": "./index.js",
     "license": "OSL-3.0",
     "dependencies": {
+        "@scandipwa/common-dev-utils": "0.0.1",
         "@scandipwa/scandipwa-dev-utils": "0.0.11",
         "semver": "^7.3.2",
         "yargs": "^16.1.0"

--- a/build-packages/magento-scripts/index.js
+++ b/build-packages/magento-scripts/index.js
@@ -2,7 +2,7 @@
 
 const yargs = require('yargs');
 const getLatestVersion = require('@scandipwa/scandipwa-dev-utils/latest-version');
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const semver = require('semver');
 const isInstalledGlobally = require('is-installed-globally');
 

--- a/build-packages/magento-scripts/lib/commands/cleanup.js
+++ b/build-packages/magento-scripts/lib/commands/cleanup.js
@@ -1,4 +1,4 @@
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { Listr } = require('listr2');
 const cleanup = require('../tasks/cleanup');
 

--- a/build-packages/magento-scripts/lib/commands/cli.js
+++ b/build-packages/magento-scripts/lib/commands/cli.js
@@ -2,7 +2,7 @@ const { Listr } = require('listr2');
 const cli = require('../tasks/cli');
 const createBashrcConfigFile = require('../tasks/cli/create-bashrc-config');
 const getMagentoVersionConfig = require('../config/get-magento-version-config');
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const getConfigFromConfigFile = require('../config/get-config-from-config-file');
 
 module.exports = (yargs) => {

--- a/build-packages/magento-scripts/lib/commands/execute.js
+++ b/build-packages/magento-scripts/lib/commands/execute.js
@@ -1,4 +1,4 @@
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { docker } = require('../config');
 const executeInContainer = require('../tasks/execute');
 

--- a/build-packages/magento-scripts/lib/commands/import-db.js
+++ b/build-packages/magento-scripts/lib/commands/import-db.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 // const path = require('path');
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { Listr } = require('listr2');
 const importDump = require('../tasks/import-dump');
 

--- a/build-packages/magento-scripts/lib/commands/link.js
+++ b/build-packages/magento-scripts/lib/commands/link.js
@@ -1,4 +1,4 @@
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { Listr } = require('listr2');
 const { linkTheme } = require('../tasks/theme');
 

--- a/build-packages/magento-scripts/lib/commands/logs.js
+++ b/build-packages/magento-scripts/lib/commands/logs.js
@@ -1,4 +1,4 @@
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { docker } = require('../config');
 const { execAsyncSpawn } = require('../util/exec-async-command');
 

--- a/build-packages/magento-scripts/lib/commands/start.js
+++ b/build-packages/magento-scripts/lib/commands/start.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 const path = require('path');
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { Listr } = require('listr2');
 const start = require('../tasks/start');
 const pathExists = require('../util/path-exists');

--- a/build-packages/magento-scripts/lib/commands/status.js
+++ b/build-packages/magento-scripts/lib/commands/status.js
@@ -1,4 +1,4 @@
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { Listr } = require('listr2');
 const getMagentoVersionConfig = require('../config/get-magento-version-config');
 const { getCachedPorts } = require('../config/get-port-config');

--- a/build-packages/magento-scripts/lib/tasks/php/compile.js
+++ b/build-packages/magento-scripts/lib/tasks/php/compile.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 const os = require('os');
 const osPlatform = require('../../util/os-platform');
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { execAsyncSpawn } = require('../../util/exec-async-command');
 
 const compileOptions = {

--- a/build-packages/magento-scripts/lib/tasks/php/index.js
+++ b/build-packages/magento-scripts/lib/tasks/php/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { execAsyncSpawn } = require('../../util/exec-async-command');
 const pathExists = require('../../util/path-exists');
 const compile = require('./compile');

--- a/build-packages/magento-scripts/lib/tasks/requirements/composer.js
+++ b/build-packages/magento-scripts/lib/tasks/requirements/composer.js
@@ -1,4 +1,4 @@
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 
 /**
  * @type {import('listr2').ListrTask<import('../../../typings/context').ListrContext>}

--- a/build-packages/magento-scripts/lib/tasks/requirements/phpbrew.js
+++ b/build-packages/magento-scripts/lib/tasks/requirements/phpbrew.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign,no-unused-vars */
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { execAsyncSpawn } = require('../../util/exec-async-command');
 const safeRegexExtract = require('../../util/safe-regex-extract');
 

--- a/build-packages/magento-scripts/lib/tasks/requirements/platform.js
+++ b/build-packages/magento-scripts/lib/tasks/requirements/platform.js
@@ -1,7 +1,7 @@
 /* eslint-disable consistent-return,no-param-reassign */
 const os = require('os');
 const macosVersion = require('macos-version');
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { platforms, darwinMinimalVersion } = require('../../config');
 const dependencyCheck = require('./dependency');
 const { getArch } = require('../../util/arch');

--- a/build-packages/magento-scripts/lib/tasks/status/index.js
+++ b/build-packages/magento-scripts/lib/tasks/status/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { getProjectCreatedAt, getPrefix } = require('../../util/prefix');
 
 const { version: packageVersion } = require('../../../package.json');

--- a/build-packages/magento-scripts/lib/util/exec-async-command.js
+++ b/build-packages/magento-scripts/lib/util/exec-async-command.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable max-len */
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const { exec, spawn } = require('child_process');
 
 const execAsync = (command, options) => new Promise((resolve, reject) => {

--- a/build-packages/magento-scripts/lib/util/install-dependencies-task.js
+++ b/build-packages/magento-scripts/lib/util/install-dependencies-task.js
@@ -1,7 +1,7 @@
 /* eslint-disable consistent-return */
 /* eslint-disable no-await-in-loop,no-param-reassign */
 const os = require('os');
-const logger = require('@scandipwa/scandipwa-dev-utils/logger');
+const logger = require('@scandipwa/common-dev-utils/logger');
 const sleep = require('./sleep');
 const { execCommandTask } = require('./exec-async-command');
 const dependenciesForPlatforms = require('../config/dependencies-for-platforms');

--- a/build-packages/magento-scripts/package.json
+++ b/build-packages/magento-scripts/package.json
@@ -22,6 +22,7 @@
         "arm64"
     ],
     "dependencies": {
+        "@scandipwa/common-dev-utils": "0.0.1",
         "@scandipwa/scandipwa-dev-utils": "^0.0.25",
         "conf": "^9.0.2",
         "enquirer": "2.3.6",


### PR DESCRIPTION
### Overview

This PR updates the development utilities to the latest version, thus using two different packages: `scandipwa-dev-utils` and `common-dev-utils`. 

This should be merged only after https://github.com/scandipwa/create-scandipwa-app/pull/54 is.