### PR TITLE
Implement disable for magento default  page builder

### DIFF
--- a/build-packages/magento-scripts/lib/tasks/link.js
+++ b/build-packages/magento-scripts/lib/tasks/link.js
@@ -6,6 +6,7 @@ const linkTheme = require('./theme/link-theme');
 const { startServices } = require('./docker');
 const { startPhpFpm } = require('./php-fpm');
 const checkConfigurationFile = require('../config/check-configuration-file');
+const { connectToMySQL } = require('./mysql');
 
 /**
  * @type {(theme: string) => import('listr2').ListrTask<import('../../typings/context').ListrContext>}
@@ -18,6 +19,7 @@ const linkTask = (themePath) => ({
         getCachedPorts(),
         startServices(),
         startPhpFpm(),
+        connectToMySQL(),
         retrieveThemeData(themePath),
         linkTheme()
     ])

--- a/build-packages/magento-scripts/lib/tasks/magento/setup-magento/disable-page-builder.js
+++ b/build-packages/magento-scripts/lib/tasks/magento/setup-magento/disable-page-builder.js
@@ -1,0 +1,11 @@
+const magentoTask = require('../../../util/magento-task');
+
+/**
+ * @type {() => import('listr2').ListrTask<import('../../../../typings/context').ListrContext>}
+ */
+const disablePageBuilder = () => ({
+    title: 'Disabling page builder in Magento',
+    task: (ctx, task) => task.newListr(magentoTask('config:set cms/pagebuilder/enabled 0'))
+});
+
+module.exports = disablePageBuilder;

--- a/build-packages/magento-scripts/lib/tasks/theme/link-theme.js
+++ b/build-packages/magento-scripts/lib/tasks/theme/link-theme.js
@@ -1,6 +1,7 @@
 const symlinkTheme = require('./symlink-theme');
 const installTheme = require('./install-theme');
 const disablePageCache = require('../magento/setup-magento/disable-page-cache');
+const disablePageBuilder = require('../magento/setup-magento/disable-page-builder');
 const buildTheme = require('./build-theme');
 const upgradeMagento = require('../magento/setup-magento/upgrade-magento');
 const setupPersistedQuery = require('./setup-persisted-query');
@@ -12,7 +13,20 @@ const updateEnvPHP = require('../php/update-env-php');
 const linkTheme = () => ({
     title: 'Linking theme',
     task: async (ctx, task) => {
-        const { absoluteThemePath, themePath, composerData } = ctx;
+        const {
+            config: { overridenConfiguration },
+            absoluteThemePath,
+            themePath,
+            composerData
+        } = ctx;
+        const {
+            magento: { edition: magentoEdition },
+            magentoVersion
+        } = overridenConfiguration;
+
+        const isEnterprise = magentoEdition === 'enterprise';
+        const isPageBuilderInstalled = isEnterprise && /^2.[4-9]/.test(magentoVersion);
+
         /**
          * @type {import('../../../typings/theme').Theme}
          */
@@ -31,6 +45,7 @@ const linkTheme = () => ({
             setupPersistedQuery(),
             upgradeMagento(),
             disablePageCache(),
+            ...(isPageBuilderInstalled ? [disablePageBuilder()] : []),
             buildTheme(theme)
         ]);
     },

--- a/build-packages/magento-scripts/lib/tasks/theme/link-theme.js
+++ b/build-packages/magento-scripts/lib/tasks/theme/link-theme.js
@@ -6,6 +6,7 @@ const buildTheme = require('./build-theme');
 const upgradeMagento = require('../magento/setup-magento/upgrade-magento');
 const setupPersistedQuery = require('./setup-persisted-query');
 const updateEnvPHP = require('../php/update-env-php');
+const semver = require('semver');
 
 /**
  * @type {() => import('listr2').ListrTask<import('../../../typings/context').ListrContext>}
@@ -25,7 +26,7 @@ const linkTheme = () => ({
         } = overridenConfiguration;
 
         const isEnterprise = magentoEdition === 'enterprise';
-        const isPageBuilderInstalled = isEnterprise && /^2.[4-9]/.test(magentoVersion);
+        const isPageBuilderInstalled = isEnterprise && semver.satisfies(semver.coerce(magentoVersion), '^2.4.0');
 
         /**
          * @type {import('../../../typings/theme').Theme}

--- a/build-packages/magento-scripts/lib/tasks/theme/link-theme.js
+++ b/build-packages/magento-scripts/lib/tasks/theme/link-theme.js
@@ -26,7 +26,7 @@ const linkTheme = () => ({
         } = overridenConfiguration;
 
         const isEnterprise = magentoEdition === 'enterprise';
-        const isPageBuilderInstalled = isEnterprise && semver.satisfies(semver.coerce(magentoVersion), '^2.4.0');
+        const isPageBuilderInstalled = isEnterprise && semver.satisfies(semver.coerce(magentoVersion), '^2.4');
 
         /**
          * @type {import('../../../typings/theme').Theme}


### PR DESCRIPTION
Fixes scandipwa/scandipwa#4006

So default page builder is not working with scandipwa page builder. As per task it is required to disable page builder on EE magento (starting from 2.4.0 version). 
