### PR TITLE
Improve support for Magento 2.3.0-2.3.6 on macos

### DIFF
--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.0.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.0.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.2.33',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.1.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.1.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.2.33',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.2-p2.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.2-p2.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.2.33',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.2.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.2.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.2.33',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.3-p1.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.3-p1.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.3.28',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.3.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.3.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.3.28',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.4-p2.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.4-p2.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.3.28',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.4.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.4.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.3.28',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.5-p1.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.5-p1.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.3.28',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.5-p2.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.5-p2.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.3.28',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.5.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.5.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.3.28',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.6-p1.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.6-p1.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.3.28',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.3.6.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.3.6.js
@@ -8,7 +8,9 @@ module.exports = ({ templateDir } = {}) => ({
             version: '7.3.28',
             configTemplate: path.join(templateDir || '', 'php.template.ini'),
             extensions: {
-                gd: {},
+                gd: {
+                    macosOptions: '--with-zlib-dir=$(brew --prefix zlib) --with-freetype-dir=$(brew --prefix freetype)'
+                },
                 intl: {},
                 zlib: {},
                 openssl: {},

--- a/build-packages/magento-scripts/lib/tasks/php/compile-options.js
+++ b/build-packages/magento-scripts/lib/tasks/php/compile-options.js
@@ -74,7 +74,8 @@ const compileOptions = {
             CPATH: '$CPATH:$(brew --prefix openssl@1.1)/include',
             CXX: 'g++ -DTRUE=1 -DFALSE=0',
             CC: 'gcc -DTRUE=1 -DFALSE=0',
-            LDFLAGS: '$(brew --prefix openssl@1.1)/lib/libssl.dylib $(brew --prefix openssl@1.1)/lib/libcrypto.dylib'
+            LDFLAGS: '$(brew --prefix openssl@1.1)/lib/libssl.dylib $(brew --prefix openssl@1.1)/lib/libcrypto.dylib',
+            CFLAGS: '-Wno-implicit-function-declaration' // https://github.com/phpbrew/phpbrew/issues/1222
         }
     }
 };

--- a/build-packages/magento-scripts/lib/tasks/php/compile.js
+++ b/build-packages/magento-scripts/lib/tasks/php/compile.js
@@ -16,7 +16,7 @@ const compile = () => ({
                 platformCompileOptions.extraOptions.push('--with-libdir=lib64');
             }
         }
-        const commandEnv = Object.entries(platformCompileOptions.env || {}).map(([key, value]) => `${key}="${value}"`).join(' && ');
+        const commandEnv = Object.entries(platformCompileOptions.env || {}).map(([key, value]) => `export ${key}="${value}"`).join(' && ');
         const phpCompileCommand = `${commandEnv ? `${commandEnv} && ` : ''} \
         phpbrew install -j ${platformCompileOptions.cpuCount} ${php.version} ${platformCompileOptions.variants.join(' ')} \
         -- ${platformCompileOptions.extraOptions.join(' ')}`;


### PR DESCRIPTION
Now PHP 7.2 and 7.3 should build as expected on mac with all extensions