### PR TITLE
Fix issues with varnish on macOS

### DIFF
--- a/build-packages/magento-scripts/lib/config/templates/nginx.template.conf
+++ b/build-packages/magento-scripts/lib/config/templates/nginx.template.conf
@@ -39,6 +39,16 @@ server {
     }
 
     location / {
+        # proxy_set_header X-Real-IP $remote_addr;
+        # proxy_set_header X-Forwarded-For $remote_addr;
+        # proxy_set_header Host $http_host;
+
+        # if ($request_method = PURGE) {
+        #     rewrite ^/(.*)$  $1 break;
+        #     proxy_pass http://<%= it.hostMachine %>:<%= it.ports.varnish %>/;
+        #     break;
+        # }
+
         try_files $uri $uri/ /index.php$is_args$args;
     }
 
@@ -212,4 +222,11 @@ server {
     location @webp-to-jpg {
         rewrite ^(.*)\.webp$ $1.jpg last;
     }
+
+    # location @purgepass {
+    #     # some other configuration
+    #     proxy_pass http://<%= it.hostMachine %>:<%= it.ports.varnish %>;
+    #     proxy_set_header Host      $host;
+    #     proxy_set_header X-Real-IP $remote_addr;
+    # }
 }

--- a/build-packages/magento-scripts/lib/config/templates/varnish.template.vcl
+++ b/build-packages/magento-scripts/lib/config/templates/varnish.template.vcl
@@ -7,19 +7,27 @@ import std;
 
 backend default {
     .host = "<%= it.hostMachine %>";
+    .host_header = "Host: localhost";
     .port = "<%= it.hostPort %>";
     .first_byte_timeout = 600s;
     .probe = {
-        .url = "/health_check.php";
-        .timeout = 2s;
-        .interval = 5s;
-        .window = 10;
-        .threshold = 5;
+        # .url = "/health_check.php";
+        .request =
+            "GET /health_check.php HTTP/1.1"
+            "Host: localhost"
+            "Connection: close"
+            "User-Agent: Varnish Health Probe";
+        .interval  = 10s;
+        .timeout   = 5s;
+        .window    = 5;
+        .threshold = 3;
    }
 }
 
 acl purge {
     "<%= it.hostMachine %>";
+    "localhost";
+    "::1";
 }
 
 sub vcl_recv {

--- a/build-packages/magento-scripts/lib/tasks/php/update-env-php.js
+++ b/build-packages/magento-scripts/lib/tasks/php/update-env-php.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const os = require('os');
 const pathExists = require('../../util/path-exists');
 const phpTask = require('../../util/php-task');
 
@@ -14,7 +15,7 @@ const updateEnvPHP = () => ({
             return;
         }
 
-        const useVarinsh = ctx.config.overridenConfiguration.configuration.varnish.enabled ? '1' : '';
+        const useVarnish = (os.platform() !== 'darwin' && ctx.config.overridenConfiguration.configuration.varnish.enabled) ? '1' : '';
         const varnishHost = '127.0.0.1';
         const varnishPort = ctx.ports.varnish;
         const previousVarnishPort = ctx.cachedPorts
@@ -25,7 +26,7 @@ const updateEnvPHP = () => ({
             phpTask(`-f ${ path.join(__dirname, 'update-env.php') }`, {
                 noTitle: true,
                 env: {
-                    USE_VARNISH: useVarinsh,
+                    USE_VARNISH: useVarnish,
                     VARNISH_PORT: `${ varnishPort }`,
                     VARNISH_HOST: varnishHost,
                     PREVIOUS_VARNISH_PORT: `${ previousVarnishPort }`


### PR DESCRIPTION
Currently, if `http_cache_hosts` settings is set in `env.php` file the following error occurs when trying to flush magento cache:
![image](https://user-images.githubusercontent.com/18352350/168860554-842a0b3e-fa89-45b4-9e1c-8f110c2822dd.png)
Looks like `scandipwa/persisted-query` module is unable to purge varnish cache or smth, although it works just fine on Linux so it comes down to networking in docker on macOS.

If `http_cache_hosts` is not set in `env.php`, then the following error occurs:
![image](https://user-images.githubusercontent.com/18352350/168860998-b74ef1bc-32ec-4ded-87dc-24b6680a72bb.png)
Now, `scandipwa/persisted-query` tries to call Nginx with PURGE request and it fails.


This PR contains some solutions that have been tried to fix the error.