### PR TITLE
Use dnf for Fedora dependency installation

### DIFF
--- a/build-packages/create-magento-app/lib/dependency/dependencies-for-platforms.js
+++ b/build-packages/create-magento-app/lib/dependency/dependencies-for-platforms.js
@@ -11,8 +11,8 @@ const dependenciesForPlatforms = {
     },
     Fedora: {
         dependencies: ['cmake'],
-        installCommand: (deps) => `sudo yum install ${deps} -y`,
-        packageManager: 'yum'
+        installCommand: (deps) => `sudo dnf install ${deps} -y`,
+        packageManager: 'dnf'
     },
     CentOS: {
         dependencies: ['cmake'],

--- a/build-packages/create-magento-app/lib/dependency/fedora.js
+++ b/build-packages/create-magento-app/lib/dependency/fedora.js
@@ -3,7 +3,7 @@ const execAsync = require('../exec-async')
 const installDependencies = require('./install-dependencies')
 
 const fedoraDependenciesCheck = async () => {
-    const installedDependencies = (await execAsync('yum list installed'))
+    const installedDependencies = (await execAsync('dnf list installed'))
         .split('\n')
         .filter((pkg) => !pkg.toLowerCase().includes('installed packages'))
         .map((pkg) => pkg.match(/^(\S+)/i))

--- a/build-packages/create-magento-app/lib/dependency/fedora.js
+++ b/build-packages/create-magento-app/lib/dependency/fedora.js
@@ -7,9 +7,10 @@ const fedoraDependenciesCheck = async () => {
         .split('\n')
         .filter((pkg) => !pkg.toLowerCase().includes('installed packages'))
         .map((pkg) => pkg.match(/^(\S+)/i))
-        .filter((pkg) => pkg)
+        .filter(Boolean)
         .map((pkg) => pkg[1])
         .map((pkg) => pkg.match(/^(\S+)\.\S+/i))
+        .filter(Boolean)
         .map((pkg) => pkg[1])
 
     const dependenciesToInstall =


### PR DESCRIPTION
- Use `dnf` package manager for dependency installation on Fedora.
- Add filtering of `dnf list installed` command parsing during dependency processing.