### PR TITLE
2.1.1

### DIFF
--- a/build-packages/magento-scripts-php-extensions/extensions/pdo_sqlsrv.js
+++ b/build-packages/magento-scripts-php-extensions/extensions/pdo_sqlsrv.js
@@ -1,8 +1,26 @@
-module.exports = {
-    // eslint-disable-next-line quotes
-    command: `apk add --no-cache --virtual .build-deps \\$PHPIZE_DEPS \
-    && pecl install pdo_sqlsrv \
+const semver = require('semver')
+
+/** @type {import('@scandipwa/magento-scripts').PHPExtensionInstallationInstruction['command']} */
+const installCommand = ({ ctx, version }) => {
+    let sqlsrvVersion = version
+    if (!sqlsrvVersion) {
+        if (semver.gte(ctx.phpVersion, '7.3.0')) {
+            sqlsrvVersion = '5.9.0'
+        }
+        if (semver.gte(ctx.phpVersion, '7.4.0')) {
+            sqlsrvVersion = '5.10.1'
+        }
+        if (semver.gte(ctx.phpVersion, '8.1.0')) {
+            sqlsrvVersion = '5.11.0'
+        }
+    }
+
+    return `apk add --no-cache --virtual .build-deps \\$PHPIZE_DEPS \
+    && pecl install pdo_sqlsrv${sqlsrvVersion ? `-${sqlsrvVersion}` : ''} \
     && docker-php-ext-enable pdo_sqlsrv \
-    && apk del -f .build-deps`,
+    && apk del -f .build-deps`
+}
+module.exports = {
+    command: installCommand,
     dependencies: ['unixodbc-dev']
 }

--- a/build-packages/magento-scripts-php-extensions/extensions/sqlsrv.js
+++ b/build-packages/magento-scripts-php-extensions/extensions/sqlsrv.js
@@ -1,8 +1,26 @@
-module.exports = {
-    // eslint-disable-next-line quotes
-    command: `apk add --no-cache --virtual .build-deps \\$PHPIZE_DEPS \
-    && pecl install sqlsrv \
+const semver = require('semver')
+
+/** @type {import('@scandipwa/magento-scripts').PHPExtensionInstallationInstruction['command']} */
+const installCommand = ({ ctx, version }) => {
+    let sqlsrvVersion = version
+    if (!sqlsrvVersion) {
+        if (semver.gte(ctx.phpVersion, '7.3.0')) {
+            sqlsrvVersion = '5.9.0'
+        }
+        if (semver.gte(ctx.phpVersion, '7.4.0')) {
+            sqlsrvVersion = '5.10.1'
+        }
+        if (semver.gte(ctx.phpVersion, '8.1.0')) {
+            sqlsrvVersion = '5.11.0'
+        }
+    }
+
+    return `apk add --no-cache --virtual .build-deps \\$PHPIZE_DEPS \
+    && pecl install sqlsrv${sqlsrvVersion ? `-${sqlsrvVersion}` : ''} \
     && docker-php-ext-enable sqlsrv \
-    && apk del -f .build-deps`,
+    && apk del -f .build-deps`
+}
+module.exports = {
+    command: installCommand,
     dependencies: ['unixodbc-dev']
 }

--- a/build-packages/magento-scripts-php-extensions/package.json
+++ b/build-packages/magento-scripts-php-extensions/package.json
@@ -5,7 +5,7 @@
     "repository": "github:scandipwa/create-magento-app",
     "main": "./index.js",
     "license": "OSL-3.0",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "os": [
         "darwin",
         "linux"

--- a/build-packages/magento-scripts/lib/tasks/docker/project-image-builder.js
+++ b/build-packages/magento-scripts/lib/tasks/docker/project-image-builder.js
@@ -49,6 +49,11 @@ const addExtensionToBuilder =
             runCommand += ` ${await Promise.resolve(
                 command({ ...extensionInstructionsWithoutCommand, ctx })
             )}`
+        } else if (typeof command === 'function') {
+            runCommand += ` ${command({
+                ...extensionInstructionsWithoutCommand,
+                ctx
+            })}`
         } else {
             runCommand += ` docker-php-ext-install ${
                 extensionInstructionsWithoutCommand.name || extensionName

--- a/build-packages/magento-scripts/package.json
+++ b/build-packages/magento-scripts/package.json
@@ -3,7 +3,7 @@
     "description": "Scripts and configuration used by CMA.",
     "homepage": "https://docs.create-magento-app.com/",
     "repository": "github:scandipwa/create-magento-app",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "main": "./index.js",
     "types": "./typings/index.d.ts",
     "license": "OSL-3.0",

--- a/sample-packages/magento-2.2.10/package.json
+++ b/sample-packages/magento-2.2.10/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.1/package.json
+++ b/sample-packages/magento-2.3.1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.2-p2/package.json
+++ b/sample-packages/magento-2.3.2-p2/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.2/package.json
+++ b/sample-packages/magento-2.3.2/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.3-p1/package.json
+++ b/sample-packages/magento-2.3.3-p1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.3/package.json
+++ b/sample-packages/magento-2.3.3/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.5-p1/package.json
+++ b/sample-packages/magento-2.3.5-p1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.5-p2/package.json
+++ b/sample-packages/magento-2.3.5-p2/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.5/package.json
+++ b/sample-packages/magento-2.3.5/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.7-p2/package.json
+++ b/sample-packages/magento-2.3.7-p2/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.7-p3/package.json
+++ b/sample-packages/magento-2.3.7-p3/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.3.7-p4/package.json
+++ b/sample-packages/magento-2.3.7-p4/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.0-p1/package.json
+++ b/sample-packages/magento-2.4.0-p1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.0/package.json
+++ b/sample-packages/magento-2.4.0/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.1-p1/package.json
+++ b/sample-packages/magento-2.4.1-p1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.1/package.json
+++ b/sample-packages/magento-2.4.1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.2-p1/package.json
+++ b/sample-packages/magento-2.4.2-p1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.2-p2/package.json
+++ b/sample-packages/magento-2.4.2-p2/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.2/package.json
+++ b/sample-packages/magento-2.4.2/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.3-p1-ioncube/package.json
+++ b/sample-packages/magento-2.4.3-p1-ioncube/package.json
@@ -17,7 +17,7 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0",
-        "@scandipwa/magento-scripts-php-extensions": "1.0.1"
+        "@scandipwa/magento-scripts": "2.1.1",
+        "@scandipwa/magento-scripts-php-extensions": "1.0.2"
     }
 }

--- a/sample-packages/magento-2.4.3-p1/package.json
+++ b/sample-packages/magento-2.4.3-p1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.3-p2/package.json
+++ b/sample-packages/magento-2.4.3-p2/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.3-p3/package.json
+++ b/sample-packages/magento-2.4.3-p3/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.3/package.json
+++ b/sample-packages/magento-2.4.3/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.4-p1/package.json
+++ b/sample-packages/magento-2.4.4-p1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.4-p2/package.json
+++ b/sample-packages/magento-2.4.4-p2/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.4-p3/package.json
+++ b/sample-packages/magento-2.4.4-p3/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.4/package.json
+++ b/sample-packages/magento-2.4.4/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.5-p1/package.json
+++ b/sample-packages/magento-2.4.5-p1/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.5-p2/package.json
+++ b/sample-packages/magento-2.4.5-p2/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.5/package.json
+++ b/sample-packages/magento-2.4.5/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }

--- a/sample-packages/magento-2.4.6/package.json
+++ b/sample-packages/magento-2.4.6/package.json
@@ -17,6 +17,6 @@
         "type": "magento"
     },
     "dependencies": {
-        "@scandipwa/magento-scripts": "2.1.0-alpha.0"
+        "@scandipwa/magento-scripts": "2.1.1"
     }
 }


### PR DESCRIPTION
- Add support for plain functions for php extensions command
- update `pdo_sqlsrv` and `sqlsrv` extensions to be compatible with all PHP versions