### PR TITLE
add enable SSL flag in cma config for easy fastcgi_param  HTTPS turn on.

### DIFF
--- a/build-packages/magento-scripts/lib/config/templates/nginx.fastcgi_params.template
+++ b/build-packages/magento-scripts/lib/config/templates/nginx.fastcgi_params.template
@@ -10,7 +10,7 @@ fastcgi_param  DOCUMENT_URI       $document_uri;
 fastcgi_param  DOCUMENT_ROOT      $document_root;
 fastcgi_param  SERVER_PROTOCOL    $server_protocol;
 fastcgi_param  REQUEST_SCHEME     $scheme;
-<% if (it.isNgrok) { %>
+<% if (it.isForwardedProto) { %>
 fastcgi_param  HTTPS              on;
 <% } else { %>
 fastcgi_param  HTTPS              $https if_not_empty;

--- a/build-packages/magento-scripts/lib/tasks/file-system/create-ssl-terminator-config.js
+++ b/build-packages/magento-scripts/lib/tasks/file-system/create-ssl-terminator-config.js
@@ -111,7 +111,7 @@ const createSSLTerminatorConfig = () => ({
                 ),
                 overwrite: true,
                 templateArgs: {
-                    isNgrok: host.endsWith('ngrok.io')
+                    isForwardedProto: ssl.forwardedProto
                 }
             })
         } catch (e) {

--- a/build-packages/magento-scripts/lib/util/config-file-validator.js
+++ b/build-packages/magento-scripts/lib/util/config-file-validator.js
@@ -52,9 +52,10 @@ const magentoSchema = Joi.object({
  * @type {Joi.ObjectSchema<import('../../typings').SSLConfiguration>}
  */
 const sslSchema = Joi.object({
-    enabled: Joi.bool().required(),
-    ssl_certificate: Joi.string().required(),
-    ssl_certificate_key: Joi.string().required()
+    enabled: Joi.bool().optional(),
+    ssl_certificate: Joi.string().optional(),
+    ssl_certificate_key: Joi.string().optional(),
+    forwardedProto: Joi.bool().optional
 })
 
 /**

--- a/build-packages/magento-scripts/lib/util/config-file-validator.js
+++ b/build-packages/magento-scripts/lib/util/config-file-validator.js
@@ -55,7 +55,7 @@ const sslSchema = Joi.object({
     enabled: Joi.bool().optional(),
     ssl_certificate: Joi.string().optional(),
     ssl_certificate_key: Joi.string().optional(),
-    forwardedProto: Joi.bool().optional
+    forwardedProto: Joi.bool().optional()
 })
 
 /**

--- a/build-packages/magento-scripts/typings/index.d.ts
+++ b/build-packages/magento-scripts/typings/index.d.ts
@@ -219,6 +219,11 @@ export interface SSLConfiguration {
      * `./ssl_certificate-key.pem`
      */
     ssl_certificate_key?: string
+
+    /**
+     * Enables fast-cgi_param HTTPS in nginx.conf for local-instance share outside local network
+     */
+    forwardedProto: boolean
 }
 
 export interface CMAConfiguration {


### PR DESCRIPTION
Since Ngrok is changed domain and on Market available alternatives - I offer to add HTTPS enable disable config what can cover #129  and allow local environment share 