### PR TITLE
Fix duplicate error for mariadb-config creation

### DIFF
--- a/build-packages/magento-scripts/lib/tasks/file-system/create-mariadb-config.js
+++ b/build-packages/magento-scripts/lib/tasks/file-system/create-mariadb-config.js
@@ -29,7 +29,7 @@ const createMariaDBConfig = () => ({
             })
         } catch (e) {
             throw new UnknownError(
-                `Unexpected error accrued during php-fpm config creation\n\n${e}`
+                `Unexpected error accrued during mariadb config creation\n\n${e}`
             )
         }
     }


### PR DESCRIPTION
`create-mariadb-config.js` has duplicated error from `create-php-fpm-config.js`.

In this PR, fixed error phrase.