### PR TITLE
TEAMS-1022 - Fix ES/OS version retrieval

### DIFF
--- a/build-packages/magento-scripts/lib/config/docker.js
+++ b/build-packages/magento-scripts/lib/config/docker.js
@@ -365,6 +365,7 @@ module.exports = async (ctx, overridenConfiguration, baseConfig) => {
                 env:
                     searchengine === 'elasticsearch'
                         ? deepmerge(
+                              defaultEsEnv,
                               {
                                   // https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-settings.html
                                   'xpack.ml.enabled': ['sse4.2', 'sse4_2'].some(
@@ -372,9 +373,9 @@ module.exports = async (ctx, overridenConfiguration, baseConfig) => {
                                           cpuSupportedFlags.includes(sse42Flag)
                                   )
                               },
-                              elasticsearch.env || defaultEsEnv
+                              elasticsearch.env || {}
                           )
-                        : deepmerge({}, opensearch.env || defaultOsEnv),
+                        : deepmerge(defaultOsEnv, opensearch.env || {}),
                 network: network.name,
                 image: `${
                     searchengine === 'elasticsearch'

--- a/build-packages/magento-scripts/typings/context.d.ts
+++ b/build-packages/magento-scripts/typings/context.d.ts
@@ -91,7 +91,7 @@ export interface ListrContext {
                     }
                 }
             >
-            getContainers(ports?: Record<string, number>): Record<string,
+            getContainers(ports?: ListrContext['ports']): Record<'php' | 'sslTerminator' | 'nginx' | 'redis' | 'mariadb' | 'elasticsearch' | 'maildev' | 'varnish',
                 {
                     _: string
                     ports: string[]


### PR DESCRIPTION
- If container is running, executes command into running container instead of creating new one
- If container is not running, get available port immediately instead of relying on provided port value- If container is running, executes command into running container instead of creating new one
- If container is not running, get available port immediately instead of relying on provided port value