### PR TITLE
TEAMS-1030 - Fix exec command argument interpolation 

### DIFF
--- a/build-packages/magento-scripts/exec.js
+++ b/build-packages/magento-scripts/exec.js
@@ -98,10 +98,10 @@ const newVersionIsAPatch = (latestVersion, currentVersion) => {
         logger.log() // add empty line
     }
 
-    const [containername, ...commands] = process.argv.slice(2)
+    const [containerName, ...commands] = process.argv.slice(2)
 
     return executeTask({
-        containername,
+        containerName,
         commands
     })
 })()

--- a/build-packages/magento-scripts/index.js
+++ b/build-packages/magento-scripts/index.js
@@ -121,6 +121,7 @@ const newVersionIsAPatch = (latestVersion, currentVersion) => {
     }
 
     yargs.scriptName('magento-scripts')
+    yargs.version(false)
 
     // Initialize program commands
     commands.forEach((command) => command(yargs))

--- a/build-packages/magento-scripts/lib/commands/execute.js
+++ b/build-packages/magento-scripts/lib/commands/execute.js
@@ -5,10 +5,10 @@ const { executeTask } = require('../tasks/execute')
  */
 module.exports = (yargs) => {
     yargs.command(
-        'exec <container name> [commands...]',
+        'exec <container name> [command...]',
         'Execute command in docker container',
         (yargs) => {
-            yargs.usage(`Usage: npm run exec <container name> [commands...]
+            yargs.usage(`Usage: npm run exec <container name> [command...]
 
 Available containers:
 - mariadb
@@ -18,8 +18,12 @@ Available containers:
 - varnish (if enabled)
 - sslTerminator`)
         },
-        async (argv) => {
-            await executeTask(argv)
+        async () => {
+            const [containerName, ...commands] = process.argv.slice(3)
+            await executeTask({
+                containerName,
+                commands
+            })
         }
     )
 }

--- a/build-packages/magento-scripts/lib/tasks/database/create-magento-database.js
+++ b/build-packages/magento-scripts/lib/tasks/database/create-magento-database.js
@@ -9,10 +9,10 @@ const createMagentoDatabase = () => ({
     task: async (ctx, task) => {
         const { mariadb } = ctx.config.docker.getContainers()
         task.title = `Creating Magento database in ${mariadb._}`
-        await containerApi.exec(
-            `mysql -uroot -p${mariadb.env.MARIADB_ROOT_PASSWORD} -h 127.0.0.1 -e "CREATE DATABASE IF NOT EXISTS magento;"`,
-            mariadb.name
-        )
+        await containerApi.exec({
+            command: `mysql -uroot -p${mariadb.env.MARIADB_ROOT_PASSWORD} -h 127.0.0.1 -e "CREATE DATABASE IF NOT EXISTS magento;"`,
+            container: mariadb.name
+        })
     }
 })
 

--- a/build-packages/magento-scripts/lib/tasks/docker/containers/container-api.d.ts
+++ b/build-packages/magento-scripts/lib/tasks/docker/containers/container-api.d.ts
@@ -38,6 +38,12 @@ export function ls(
 ): Promise<ContainerLsResult[]>
 
 export interface ContainerExecOptions {
+    command: string
+
+    /**
+     * container id or name
+     */
+    container: string
     /**
      * Set environment variables [docs](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
      */
@@ -60,11 +66,11 @@ export interface ContainerExecOptions {
 }
 
 export function exec<T>(
-    command: string,
-    container: string,
-    options?: ContainerExecOptions,
+    options: ContainerExecOptions,
     execOptions?: ExecAsyncSpawnOptions<T>
 ): Promise<string>
+
+export function execCommand(options: ContainerExecOptions): string[]
 
 export interface ContainerRunOptions {
     /**

--- a/build-packages/magento-scripts/lib/tasks/docker/containers/container-api.js
+++ b/build-packages/magento-scripts/lib/tasks/docker/containers/container-api.js
@@ -100,13 +100,10 @@ const run = (options, execOptions = {}) =>
     execAsyncSpawn(runCommand(options).join(' '), execOptions)
 
 /**
- * @param {string} command
- * @param {string} container container id or name
  * @param {import('./container-api').ContainerExecOptions} options
- * @param {import('../../../util/exec-async-command').ExecAsyncSpawnOptions<false>} execOptions
  */
-const exec = (command, container, options = {}, execOptions = {}) => {
-    const { env, tty, user, workdir } = options
+const execCommand = (options) => {
+    const { command, container, env, tty, user, workdir } = options
     const envArgs = !env
         ? ''
         : Object.entries(env)
@@ -116,7 +113,7 @@ const exec = (command, container, options = {}, execOptions = {}) => {
     const userArg = user ? `--user=${user}` : ''
     const workdirArg = workdir ? `--workdir=${workdir}` : ''
 
-    const execCommand = [
+    const dockerCommand = [
         'docker',
         'container',
         'exec',
@@ -127,11 +124,18 @@ const exec = (command, container, options = {}, execOptions = {}) => {
         container,
         command
     ]
-        .filter(Boolean)
-        .join(' ')
+        .flat()
+        .filter((arg) => !!arg && typeof arg === 'string')
 
-    return execAsyncSpawn(execCommand, execOptions)
+    return dockerCommand
 }
+
+/**
+ * @param {import('./container-api').ContainerExecOptions} options
+ * @param {import('../../../util/exec-async-command').ExecAsyncSpawnOptions<false>} execOptions
+ */
+const exec = (options, execOptions = {}) =>
+    execAsyncSpawn(execCommand(options).join(' '), execOptions)
 
 /**
  * @type {typeof import('./container-api')['ls']}
@@ -243,6 +247,7 @@ module.exports = {
     run,
     runCommand,
     exec,
+    execCommand,
     ls,
     logs,
     stop,

--- a/build-packages/magento-scripts/lib/tasks/docker/convert-mysql-to-mariadb.js
+++ b/build-packages/magento-scripts/lib/tasks/docker/convert-mysql-to-mariadb.js
@@ -190,15 +190,18 @@ Please wait, this will take some time and do not restart the MySQL container unt
                 task.output = 'Dumping MySQL database to dump file...'
 
                 await containerApi.exec(
-                    [
-                        'mysqldump',
-                        '--user=root',
-                        '--password=scandipwa',
-                        'magento',
-                        `--result-file=${path.parse(pathToMySQLDumpFile).base}`
-                    ].join(' '),
-                    containerName,
-                    {},
+                    {
+                        container: containerName,
+                        command: [
+                            'mysqldump',
+                            '--user=root',
+                            '--password=scandipwa',
+                            'magento',
+                            `--result-file=${
+                                path.parse(pathToMySQLDumpFile).base
+                            }`
+                        ].join(' ')
+                    },
                     {
                         callback: (t) => {
                             task.output = t

--- a/build-packages/magento-scripts/lib/tasks/execute.js
+++ b/build-packages/magento-scripts/lib/tasks/execute.js
@@ -95,7 +95,7 @@ const executeTask = async (argv) => {
 
             const result = await executeInContainer({
                 containerName: container.name,
-                commands: argv.commands,
+                command: argv.commands.join(' '),
                 user: container.user
             })
 

--- a/build-packages/magento-scripts/lib/tasks/execute.js
+++ b/build-packages/magento-scripts/lib/tasks/execute.js
@@ -15,7 +15,7 @@ const KnownError = require('../errors/known-error')
 
 /**
  *
- * @param {{ containername: string, commands: string[] }} argv
+ * @param {{ containerName: string, commands: string[] }} argv
  * @returns
  */
 const executeTask = async (argv) => {
@@ -47,17 +47,17 @@ const executeTask = async (argv) => {
     const services = Object.keys(containers)
 
     if (
-        services.includes(argv.containername) ||
-        services.some((service) => service.includes(argv.containername))
+        services.includes(argv.containerName) ||
+        services.some((service) => service.includes(argv.containerName))
     ) {
-        const containerResult = containers[argv.containername]
-            ? containers[argv.containername]
+        const containerResult = containers[argv.containerName]
+            ? containers[argv.containerName]
             : Object.entries(containers).find(([key]) =>
-                  key.includes(argv.containername)
+                  key.includes(argv.containerName)
               )
 
         if (!containerResult) {
-            logger.error(`No container found "${argv.containername}"`)
+            logger.error(`No container found "${argv.containerName}"`)
             process.exit(1)
         }
 
@@ -127,7 +127,7 @@ const executeTask = async (argv) => {
         throw new KnownError(`Container ${container.name} is not running!`)
     }
 
-    logger.error(`No container found "${argv.containername}"`)
+    logger.error(`No container found "${argv.containerName}"`)
     process.exit(1)
 }
 

--- a/build-packages/magento-scripts/lib/tasks/php/php-container.js
+++ b/build-packages/magento-scripts/lib/tasks/php/php-container.js
@@ -70,16 +70,11 @@ const execPHPContainerCommand = async (ctx, command, options = {}) => {
     }
 
     return containerApi.exec(
-        command,
-        php.name,
-        deepmerge(
-            php,
-            options.env
-                ? {
-                      env: options.env
-                  }
-                : {}
-        ),
+        {
+            container: php.name,
+            ...deepmerge(php, options.env ? { env: options.env } : {}),
+            command
+        },
         options
     )
 }

--- a/build-packages/magento-scripts/lib/tasks/requirements/elasticsearch-version.js
+++ b/build-packages/magento-scripts/lib/tasks/requirements/elasticsearch-version.js
@@ -26,10 +26,10 @@ const checkElasticSearchVersion = () => ({
             elasticSearchContainerRunning.length !== 0 &&
             elasticSearchContainerRunning[0].State === 'running'
         ) {
-            elasticSearchVersionResponse = await containerApi.exec(
-                'elasticsearch --version',
-                elasticSearchContainer.name
-            )
+            elasticSearchVersionResponse = await containerApi.exec({
+                command: 'elasticsearch --version',
+                container: elasticSearchContainer.name
+            })
         } else {
             try {
                 const availableElasticSearchPort = await getPort(

--- a/build-packages/magento-scripts/lib/tasks/requirements/opensearch-version.js
+++ b/build-packages/magento-scripts/lib/tasks/requirements/opensearch-version.js
@@ -25,10 +25,10 @@ const checkOpenSearchVersion = () => ({
             openSearchContainerRunning.length !== 0 &&
             openSearchContainerRunning[0].State === 'running'
         ) {
-            openSearchVersionResponse = await containerApi.exec(
-                'opensearch --version',
-                openSearchContainer.name
-            )
+            openSearchVersionResponse = await containerApi.exec({
+                command: 'opensearch --version',
+                container: openSearchContainer.name
+            })
         } else {
             try {
                 const availableOpenSearchPort = await getPort(

--- a/build-packages/magento-scripts/lib/util/execute-in-container.js
+++ b/build-packages/magento-scripts/lib/util/execute-in-container.js
@@ -1,22 +1,26 @@
 const { spawn } = require('child_process')
-const { runCommand } = require('../tasks/docker/containers/container-api')
+const {
+    runCommand,
+    execCommand
+} = require('../tasks/docker/containers/container-api')
 
 /**
- * @param {{ containerName: string, commands: string[], user?: string }} param0
+ * @param {{ containerName: string, command: string, user?: string }} param0
  * @returns {Promise<never>}
  */
-const executeInContainer = ({ containerName, commands, user }) => {
+const executeInContainer = ({ containerName, command, user }) => {
     if (!process.stdin.isTTY) {
         process.stderr.write('This app works only in TTY mode')
         process.exit(1)
     }
 
-    const userArg = (user && `--user=${user}`) || ''
-    const args = ['exec', '-it', userArg, containerName]
-        .filter(Boolean)
-        .concat(...commands.map((command) => command.split(' ')).flat())
+    const execArgs = execCommand({
+        container: containerName,
+        command,
+        user
+    })
 
-    spawn('docker', args, {
+    spawn('bash', ['-c', execArgs.join(' ')], {
         stdio: [0, 1, 2]
     })
 


### PR DESCRIPTION
- Make `container.exec` command api standardized by re-using run command api