### PR TITLE
Add support for new Magento versions

### DIFF
--- a/build-packages/magento-scripts/lib/config/services/composer/versions/composer-2.9.js
+++ b/build-packages/magento-scripts/lib/config/services/composer/versions/composer-2.9.js
@@ -2,7 +2,7 @@
  * @returns {import('../../../../../typings/index').ComposerConfiguration}
  */
 const composer29 = () => ({
-    version: '2.9.5'
+    version: '2.9.8'
 })
 
 module.exports = composer29

--- a/build-packages/magento-scripts/lib/config/services/mariadb/versions/index.js
+++ b/build-packages/magento-scripts/lib/config/services/mariadb/versions/index.js
@@ -5,5 +5,6 @@ module.exports = {
     mariadb106: require('./mariadb-10.6'),
     mariadb1011: require('./mariadb-10.11'),
     mariadb114: require('./mariadb-11.4'),
-    mariadb116: require('./mariadb-11.6')
+    mariadb116: require('./mariadb-11.6'),
+    mariadb118: require('./mariadb-11.8')
 }

--- a/build-packages/magento-scripts/lib/config/services/mariadb/versions/mariadb-11.8.js
+++ b/build-packages/magento-scripts/lib/config/services/mariadb/versions/mariadb-11.8.js
@@ -1,0 +1,11 @@
+/**
+ * @returns {import('../../../../../typings/index').MariaDBConfiguration}
+ */
+const mariadb118 = () => ({
+    image: 'mariadb:11.8',
+    useOptimizerSwitch: true,
+    binFileName: 'mariadb',
+    binAdminFileName: 'mariadb-admin'
+})
+
+module.exports = mariadb118

--- a/build-packages/magento-scripts/lib/config/services/redis/index.js
+++ b/build-packages/magento-scripts/lib/config/services/redis/index.js
@@ -1,5 +1,6 @@
 const valkey80 = require('./valkey-8.0')
 const valkey81 = require('./valkey-8.1')
+const valkey90 = require('./valkey-9.0')
 
 module.exports = {
     redis50: require('./redis-5.0'),
@@ -8,5 +9,6 @@ module.exports = {
     redis70: require('./redis-7.0'),
     redis72: require('./redis-7.2'),
     valkey80,
-    valkey81
+    valkey81,
+    valkey90
 }

--- a/build-packages/magento-scripts/lib/config/services/redis/valkey-9.0.js
+++ b/build-packages/magento-scripts/lib/config/services/redis/valkey-9.0.js
@@ -1,0 +1,8 @@
+/**
+ * @returns {import('../../../../typings/index').ServiceWithImage}
+ */
+const valkey90 = () => ({
+    image: 'valkey/valkey:9.0-alpine'
+})
+
+module.exports = valkey90

--- a/build-packages/magento-scripts/lib/config/services/varnish/index.js
+++ b/build-packages/magento-scripts/lib/config/services/varnish/index.js
@@ -7,5 +7,6 @@ module.exports = {
     varnish74: require('./varnish-7-4'),
     varnish75: require('./varnish-7-5'),
     varnish76: require('./varnish-7-6'),
-    varnish77: require('./varnish-7-7')
+    varnish77: require('./varnish-7-7'),
+    varnish80: require('./varnish-8-0')
 }

--- a/build-packages/magento-scripts/lib/config/services/varnish/varnish-8-0.js
+++ b/build-packages/magento-scripts/lib/config/services/varnish/varnish-8-0.js
@@ -1,0 +1,15 @@
+const path = require('path')
+
+/**
+ * @param {Object} param0
+ * @param {string} param0.templateDir
+ * @returns {import('../../../../typings/index').VarnishConfiguration}
+ */
+const varnish80 = ({ templateDir }) => ({
+    enabled: false,
+    healthCheck: false,
+    image: 'varnish:8.0',
+    configTemplate: path.join(templateDir || '', 'varnish.template.vcl')
+})
+
+module.exports = varnish80

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.4.4-p18.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.4.4-p18.js
@@ -1,0 +1,43 @@
+const sodium = require('../services/php/extensions/sodium')
+const {
+    magento24PHPExtensionList
+} = require('../magento/required-php-extensions')
+const { php81 } = require('../services/php/versions')
+const { sslTerminator } = require('../services/ssl-terminator')
+const { varnish77 } = require('../services/varnish')
+const { repo } = require('../services/php/base-repo')
+const { nginx128 } = require('../services/nginx/versions')
+const { composer22 } = require('../services/composer/versions')
+const { maildev } = require('../services/maildev')
+const { redis72 } = require('../services/redis')
+const { mariadb106 } = require('../services/mariadb/versions')
+const { elasticsearch717 } = require('../services/elasticsearch/versions')
+const { mysql80 } = require('../services/mysql/versions')
+const { opensearch219 } = require('../services/opensearch/versions')
+
+/**
+ * @type {import('../../../typings/common').MagentoVersionConfigurationFunction}
+ */
+module.exports = ({ templateDir }) => ({
+    magentoVersion: '2.4.4-p18',
+    configuration: {
+        php: php81({
+            templateDir,
+            extensions: { ...magento24PHPExtensionList, sodium },
+            baseImage: `${repo}:php-8.1-magento-2.4`
+        }),
+        nginx: nginx128({ templateDir }),
+        redis: redis72(),
+        // not supported anymore
+        mysql: mysql80(),
+        mariadb: mariadb106(),
+        // not supported anymore
+        elasticsearch: elasticsearch717(),
+        composer: composer22(),
+        varnish: varnish77({ templateDir }),
+        sslTerminator: sslTerminator({ templateDir }),
+        maildev: maildev(),
+        opensearch: opensearch219(),
+        searchengine: 'opensearch'
+    }
+})

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.4.5-p17.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.4.5-p17.js
@@ -1,0 +1,43 @@
+const sodium = require('../services/php/extensions/sodium')
+const {
+    magento24PHPExtensionList
+} = require('../magento/required-php-extensions')
+const { php81 } = require('../services/php/versions')
+const { sslTerminator } = require('../services/ssl-terminator')
+const { varnish80 } = require('../services/varnish')
+const { repo } = require('../services/php/base-repo')
+const { nginx128 } = require('../services/nginx/versions')
+const { composer22 } = require('../services/composer/versions')
+const { maildev } = require('../services/maildev')
+const { valkey81 } = require('../services/redis')
+const { mariadb106 } = require('../services/mariadb/versions')
+const { elasticsearch717 } = require('../services/elasticsearch/versions')
+const { mysql80 } = require('../services/mysql/versions')
+const { opensearch219 } = require('../services/opensearch/versions')
+
+/**
+ * @type {import('../../../typings/common').MagentoVersionConfigurationFunction}
+ */
+module.exports = ({ templateDir }) => ({
+    magentoVersion: '2.4.5-p17',
+    configuration: {
+        php: php81({
+            templateDir,
+            extensions: { ...magento24PHPExtensionList, sodium },
+            baseImage: `${repo}:php-8.1-magento-2.4`
+        }),
+        nginx: nginx128({ templateDir }),
+        redis: valkey81(),
+        // not supported anymore
+        mysql: mysql80(),
+        mariadb: mariadb106(),
+        // not supported anymore
+        elasticsearch: elasticsearch717(),
+        composer: composer22(),
+        varnish: varnish80({ templateDir }),
+        sslTerminator: sslTerminator({ templateDir }),
+        maildev: maildev(),
+        opensearch: opensearch219(),
+        searchengine: 'opensearch'
+    }
+})

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.4.6-p15.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.4.6-p15.js
@@ -1,0 +1,43 @@
+const sodium = require('../services/php/extensions/sodium')
+const {
+    magento24PHPExtensionList
+} = require('../magento/required-php-extensions')
+const { php81 } = require('../services/php/versions')
+const { sslTerminator } = require('../services/ssl-terminator')
+const { varnish80 } = require('../services/varnish')
+const { repo } = require('../services/php/base-repo')
+const { nginx128 } = require('../services/nginx/versions')
+const { composer22 } = require('../services/composer/versions')
+const { maildev } = require('../services/maildev')
+const { valkey81 } = require('../services/redis')
+const { mariadb1011 } = require('../services/mariadb/versions')
+const { elasticsearch717 } = require('../services/elasticsearch/versions')
+const { mysql80 } = require('../services/mysql/versions')
+const { opensearch219 } = require('../services/opensearch/versions')
+
+/**
+ * @type {import('../../../typings/common').MagentoVersionConfigurationFunction}
+ */
+module.exports = ({ templateDir }) => ({
+    magentoVersion: '2.4.6-p15',
+    configuration: {
+        php: php81({
+            templateDir,
+            extensions: { ...magento24PHPExtensionList, sodium },
+            baseImage: `${repo}:php-8.1-magento-2.4`
+        }),
+        nginx: nginx128({ templateDir }),
+        redis: valkey81(),
+        // not supported anymore
+        mysql: mysql80(),
+        mariadb: mariadb1011(),
+        // not supported anymore
+        elasticsearch: elasticsearch717(),
+        composer: composer22(),
+        varnish: varnish80({ templateDir }),
+        sslTerminator: sslTerminator({ templateDir }),
+        maildev: maildev(),
+        opensearch: opensearch219(),
+        searchengine: 'opensearch'
+    }
+})

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.4.7-p10.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.4.7-p10.js
@@ -1,42 +1,42 @@
 const sodium = require('../services/php/extensions/sodium')
-const ftp = require('../services/php/extensions/ftp')
 const {
     magento24PHPExtensionList
 } = require('../magento/required-php-extensions')
-const { php83 } = require('../services/php/versions')
+const { php82 } = require('../services/php/versions')
 const { sslTerminator } = require('../services/ssl-terminator')
-const { varnish76 } = require('../services/varnish')
+const { varnish80 } = require('../services/varnish')
 const { repo } = require('../services/php/base-repo')
 const { nginx128 } = require('../services/nginx/versions')
 const { composer29 } = require('../services/composer/versions')
 const { maildev } = require('../services/maildev')
-const { valkey80 } = require('../services/redis')
-const { mariadb114 } = require('../services/mariadb/versions')
+const { valkey81 } = require('../services/redis')
+const { mariadb1011 } = require('../services/mariadb/versions')
 const { elasticsearch817 } = require('../services/elasticsearch/versions')
 const { mysql80 } = require('../services/mysql/versions')
-const { opensearch300 } = require('../services/opensearch/versions')
+const { opensearch219 } = require('../services/opensearch/versions')
 
 /**
  * @type {import('../../../typings/common').MagentoVersionConfigurationFunction}
  */
 module.exports = ({ templateDir }) => ({
-    magentoVersion: '2.4.8-p4',
+    magentoVersion: '2.4.7-p10',
     configuration: {
-        php: php83({
+        php: php82({
             templateDir,
-            extensions: { ...magento24PHPExtensionList, sodium, ftp },
-            baseImage: `${repo}:php-8.3-magento-2.4`
+            extensions: { ...magento24PHPExtensionList, sodium },
+            baseImage: `${repo}:php-8.2-magento-2.4`
         }),
         nginx: nginx128({ templateDir }),
-        redis: valkey80(),
+        redis: valkey81(),
+        // not supported anymore
         mysql: mysql80(),
-        mariadb: mariadb114(),
+        mariadb: mariadb1011(),
         elasticsearch: elasticsearch817(),
         composer: composer29(),
-        varnish: varnish76({ templateDir }),
+        varnish: varnish80({ templateDir }),
         sslTerminator: sslTerminator({ templateDir }),
         maildev: maildev(),
-        opensearch: opensearch300(),
+        opensearch: opensearch219(),
         searchengine: 'opensearch'
     }
 })

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.4.8-p5.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.4.8-p5.js
@@ -5,7 +5,7 @@ const {
 } = require('../magento/required-php-extensions')
 const { php83 } = require('../services/php/versions')
 const { sslTerminator } = require('../services/ssl-terminator')
-const { varnish76 } = require('../services/varnish')
+const { varnish80 } = require('../services/varnish')
 const { repo } = require('../services/php/base-repo')
 const { nginx128 } = require('../services/nginx/versions')
 const { composer29 } = require('../services/composer/versions')
@@ -20,7 +20,7 @@ const { opensearch300 } = require('../services/opensearch/versions')
  * @type {import('../../../typings/common').MagentoVersionConfigurationFunction}
  */
 module.exports = ({ templateDir }) => ({
-    magentoVersion: '2.4.8-p4',
+    magentoVersion: '2.4.8-p5',
     configuration: {
         php: php83({
             templateDir,
@@ -33,7 +33,7 @@ module.exports = ({ templateDir }) => ({
         mariadb: mariadb114(),
         elasticsearch: elasticsearch817(),
         composer: composer29(),
-        varnish: varnish76({ templateDir }),
+        varnish: varnish80({ templateDir }),
         sslTerminator: sslTerminator({ templateDir }),
         maildev: maildev(),
         opensearch: opensearch300(),

--- a/build-packages/magento-scripts/lib/config/versions/magento-2.4.9.js
+++ b/build-packages/magento-scripts/lib/config/versions/magento-2.4.9.js
@@ -5,35 +5,37 @@ const {
 } = require('../magento/required-php-extensions')
 const { php83 } = require('../services/php/versions')
 const { sslTerminator } = require('../services/ssl-terminator')
-const { varnish76 } = require('../services/varnish')
+const { varnish80 } = require('../services/varnish')
 const { repo } = require('../services/php/base-repo')
 const { nginx128 } = require('../services/nginx/versions')
 const { composer29 } = require('../services/composer/versions')
 const { maildev } = require('../services/maildev')
-const { valkey80 } = require('../services/redis')
-const { mariadb114 } = require('../services/mariadb/versions')
+const { valkey90 } = require('../services/redis')
+const { mariadb118 } = require('../services/mariadb/versions')
 const { elasticsearch817 } = require('../services/elasticsearch/versions')
-const { mysql80 } = require('../services/mysql/versions')
+const { mysql84 } = require('../services/mysql/versions')
 const { opensearch300 } = require('../services/opensearch/versions')
 
 /**
  * @type {import('../../../typings/common').MagentoVersionConfigurationFunction}
  */
 module.exports = ({ templateDir }) => ({
-    magentoVersion: '2.4.8-p4',
+    magentoVersion: '2.4.9',
+    isDefault: true,
     configuration: {
         php: php83({
             templateDir,
             extensions: { ...magento24PHPExtensionList, sodium, ftp },
-            baseImage: `${repo}:php-8.3-magento-2.4`
+            baseImage: `${repo}:php-8.5-magento-2.4`
         }),
         nginx: nginx128({ templateDir }),
-        redis: valkey80(),
-        mysql: mysql80(),
-        mariadb: mariadb114(),
+        redis: valkey90(),
+        mysql: mysql84(),
+        mariadb: mariadb118(),
+        // not supported
         elasticsearch: elasticsearch817(),
         composer: composer29(),
-        varnish: varnish76({ templateDir }),
+        varnish: varnish80({ templateDir }),
         sslTerminator: sslTerminator({ templateDir }),
         maildev: maildev(),
         opensearch: opensearch300(),


### PR DESCRIPTION
- Magento 2.4.9, 2.4.8-p5, 2.4.7-p10, 2.4.6-p15, 2.4.5-p17, 2.4.4-p18
- Updated Composer to 2.9.8
- Added Valkey 9, Varnish 8, MariaDB 11.8 services